### PR TITLE
hotfix: key name typo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -130,5 +130,5 @@ jobs:
               --restart unless-stopped \
               -p ${{ env.PORT }}:${{ env.PORT }} \
               -e PORT=${{ env.PORT }} \
-              -e GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }} \
+              -e GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }} \
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/bin/project
+++ b/bin/project
@@ -16,7 +16,7 @@ case "$COMMAND" in
     run-container)
         docker run --rm\
           -p 8060:8060\
-          -e GEMINI_API_KEY=${GEMINI_API_KEY}\
+          -e GOOGLE_API_KEY=${GOOGLE_API_KEY}\
           llm-gateway
         ;;
     test-api)

--- a/scripts/test_gemini_real.py
+++ b/scripts/test_gemini_real.py
@@ -9,7 +9,7 @@ async def test_real_gemini_call():
     print("--- Real Gemini API Call Test (Sequential) ---")
 
     # 0. Check for API Key
-    assert settings.GEMINI_API_KEY, "GEMINI_API_KEY not found in settings."
+    assert settings.GOOGLE_API_KEY, "GOOGLE_API_KEY not found in settings."
 
     provider = GeminiProvider()
 

--- a/src/llm_gateway/core/config.py
+++ b/src/llm_gateway/core/config.py
@@ -7,7 +7,7 @@ class Settings(BaseSettings):
 
     # LLM Keys
     OPENAI_API_KEY: str | None = None
-    GEMINI_API_KEY: str | None = None
+    GOOGLE_API_KEY: str | None = None
 
     # Model Configuration
     GEMINI_DEFAULT_MODEL: str = "gemini-2.0-flash-lite-001"

--- a/src/llm_gateway/services/providers/gemini.py
+++ b/src/llm_gateway/services/providers/gemini.py
@@ -17,10 +17,10 @@ from llm_gateway.services.providers.base import BaseLLMProvider
 
 class GeminiProvider(BaseLLMProvider):
     def __init__(self):
-        if not settings.GEMINI_API_KEY:
-            raise ValueError("GEMINI_API_KEY is not set in environment variables.")
+        if not settings.GOOGLE_API_KEY:
+            raise ValueError("GOOGLE_API_KEY is not set in environment variables.")
         # Client 초기화는 동기적으로 수행
-        self.client = genai.Client(api_key=settings.GEMINI_API_KEY)
+        self.client = genai.Client(api_key=settings.GOOGLE_API_KEY)
 
     def _convert_messages(
         self, messages: list[ChatMessage]

--- a/src/llm_gateway/services/router.py
+++ b/src/llm_gateway/services/router.py
@@ -9,7 +9,7 @@ class LLMRouter:
         self.providers: dict[str, BaseLLMProvider] = {}
 
         # Initialize Providers if keys are present
-        if settings.GEMINI_API_KEY:
+        if settings.GOOGLE_API_KEY:
             self.providers["google"] = GeminiProvider()
 
         # 추후 OpenAI 등 추가

--- a/tests/services/test_gemini.py
+++ b/tests/services/test_gemini.py
@@ -10,7 +10,7 @@ from llm_gateway.services.providers.gemini import GeminiProvider
 @pytest.fixture
 def mock_settings():
     with patch("llm_gateway.services.providers.gemini.settings") as mock:
-        mock.GEMINI_API_KEY = "fake-key"
+        mock.GOOGLE_API_KEY = "fake-key"
         yield mock
 
 


### PR DESCRIPTION
## 관련 이슈

- close #11 

## 변경 사항

- GEMINI_API_KEY > GOOGLE_API_KEY

## 배경

- 제미나이 키는 구글 api키 명칭으로 주입됨
- 표준 키 명칭 사용으로 변경

## 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 테스트 코드 추가/수정 (해당 시)
- [x] 문서 업데이트 (해당 시)
- [x] 불필요한 코드/주석 제거
