### PR TITLE
Feat/21 OpenAI routing

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -90,16 +90,17 @@ llm-router/
 - [x] `src/llm_gateway/main.py` 헬스 체크 엔드포인트 구현 완료.
 - [x] 환경 변수 관리(`pydantic-settings`) 설정 완료.
 
-### Phase 2: LLM Provider 연동 (진행 중)
+### Phase 2: LLM Provider 연동 (완료)
 
 - [x] Provider 추상 클래스(`BaseLLMProvider`) 정의.
 - [x] Google Gemini Provider 구현 및 연동.
-- [ ] OpenAI Provider 구현 및 연동.
+- [x] OpenAI Provider 구현 및 연동.
 
-### Phase 3: 라우팅 및 서비스 로직
+### Phase 3: 라우팅 및 서비스 로직 (완료)
 
-- [ ] 모델 별칭(Alias) 시스템 구현 (예: `creative` -> `gpt-4`, `fast` -> `gemini-flash`).
-- [ ] `/v1/chat/completions` 엔드포인트 구현.
+- [x] 모델 별칭(Alias) 시스템 구현 (예: `gpt-*` -> OpenAI, `gemini-*` -> Gemini).
+- [x] `/v1/chat/completions` 엔드포인트 구현.
+- [x] 런타임 모델 라우팅 설정 관리 API 구현.
 - [ ] 스트리밍(Streaming) 응답 지원.
 
 ### Phase 4: 관측성 및 안정화

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "fastapi>=0.128.0",
     "google-genai>=1.59.0",
     "httpx>=0.28.1",
+    "openai>=2.16.0",
     "pydantic-settings>=2.12.0",
     "tenacity>=9.1.2",
     "uvicorn>=0.40.0",

--- a/scripts/test_gateway_api.py
+++ b/scripts/test_gateway_api.py
@@ -1,0 +1,58 @@
+import requests
+
+BASE_URL = "http://localhost:8000/api/v1"
+
+
+def test_api_routing():
+    print("--- API Gateway Integration Test ---")
+
+    # 1. Check Health
+    try:
+        resp = requests.get("http://localhost:8000/health")
+        if resp.status_code != 200:
+            print("ERROR: Server is not healthy.")
+            return
+    except requests.exceptions.ConnectionError:
+        print("SKIP: Server is not running at localhost:8000")
+        return
+
+    # 2. Test OpenAI Routing (gpt-* model name)
+    print("\n[Step 1] Testing OpenAI Routing via model name...")
+    payload = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "Hi, who are you?"}],
+    }
+    resp = requests.post(f"{BASE_URL}/chat/completions", json=payload)
+    print(f"Status: {resp.status_code}")
+    if resp.status_code == 200:
+        print(f"Response Model: {resp.json()['model']}")
+
+    # 3. Test Gemini Routing (gemini-* model name)
+    print("\n[Step 2] Testing Gemini Routing via model name...")
+    payload = {
+        "model": "gemini-2.0-flash",
+        "messages": [{"role": "user", "content": "Hi, who are you?"}],
+    }
+    resp = requests.post(f"{BASE_URL}/chat/completions", json=payload)
+    print(f"Status: {resp.status_code}")
+    if resp.status_code == 200:
+        print(f"Response Model: {resp.json()['model']}")
+
+    # 4. Test Config Change
+    print("\n[Step 3] Changing Default Provider to 'openai'...")
+    resp = requests.post(
+        f"{BASE_URL}/gateway/config", json={"default_provider": "openai"}
+    )
+    print(f"Config update: {resp.json()}")
+
+    print("\n[Step 4] Testing 'default' model routing (should be OpenAI now)...")
+    payload = {"model": "default", "messages": [{"role": "user", "content": "Ping"}]}
+    resp = requests.post(f"{BASE_URL}/chat/completions", json=payload)
+    if resp.status_code == 200:
+        print(f"Response Model: {resp.json()['model']}")
+
+    print("\n--- API Tests Completed ---")
+
+
+if __name__ == "__main__":
+    test_api_routing()

--- a/scripts/test_gemini_real.py
+++ b/scripts/test_gemini_real.py
@@ -1,8 +1,8 @@
 import asyncio
 
 from llm_gateway.core.config import settings
+from llm_gateway.extensions.providers.gemini import GeminiProvider
 from llm_gateway.schemas.chat import ChatMessage, ChatRequest
-from llm_gateway.services.providers.gemini import GeminiProvider
 
 
 async def test_real_gemini_call():
@@ -16,7 +16,7 @@ async def test_real_gemini_call():
     # 1. Basic Chat Test
     print("\n[Step 1] Testing Basic Chat...")
     request = ChatRequest(
-        model="gemini-2.0-flash-light",
+        model="gemini-2.0-flash",
         messages=[
             ChatMessage(
                 role="user",
@@ -34,7 +34,7 @@ async def test_real_gemini_call():
     # 2. JSON Mode Test
     print("\n[Step 2] Testing JSON Mode (Structured Output)...")
     request_json = ChatRequest(
-        model="gemini-2.0-flash-light",
+        model="gemini-2.0-flash",
         messages=[
             ChatMessage(
                 role="system",

--- a/scripts/test_openai_real.py
+++ b/scripts/test_openai_real.py
@@ -55,7 +55,10 @@ async def test_real_openai_call():
         data = json.loads(response_json.choices[0].message.content)
         print(f"Result: SUCCESS (Parsed JSON: {data})")
     except json.JSONDecodeError:
-        error_msg = f"Result: FAILURE (Invalid JSON: {response_json.choices[0].message.content})"
+        error_msg = (
+            "Result: FAILURE (Invalid JSON: "
+            f"{response_json.choices[0].message.content})"
+        )
         print(error_msg)
 
     print("\n--- OpenAI Tests Completed ---")

--- a/scripts/test_openai_real.py
+++ b/scripts/test_openai_real.py
@@ -1,0 +1,65 @@
+import asyncio
+import json
+
+from llm_gateway.core.config import settings
+from llm_gateway.extensions.providers.openai import OpenAIProvider
+from llm_gateway.schemas.chat import ChatMessage, ChatRequest
+
+
+async def test_real_openai_call():
+    print("--- Real OpenAI API Call Test ---")
+
+    # 0. Check for API Key
+    if not settings.OPENAI_API_KEY:
+        print("SKIP: OPENAI_API_KEY not found in settings.")
+        return
+
+    provider = OpenAIProvider()
+
+    # 1. Basic Chat Test
+    print("\n[Step 1] Testing Basic Chat (GPT-4o-mini)...")
+    content = "TRPG에서 다이스 갓(Dice God)이라는 표현의 유래를 한 줄로 알려줘."
+    request = ChatRequest(
+        model="gpt-4o-mini",
+        messages=[ChatMessage(role="user", content=content)],
+        temperature=0.7,
+    )
+
+    response = await provider.chat_complete(request)
+    assert response.choices[0].message.content, "Empty response from OpenAI."
+    print("Result: SUCCESS")
+    print(f"Response: {response.choices[0].message.content}")
+
+    # 2. JSON Mode Test
+    print("\n[Step 2] Testing JSON Mode...")
+    request_json = ChatRequest(
+        model="gpt-4o-mini",
+        messages=[
+            ChatMessage(
+                role="system",
+                content="You are a character generator. Output MUST be in JSON.",
+            ),
+            ChatMessage(
+                role="user",
+                content="Generate a simple warrior character name and stat(STR).",
+            ),
+        ],
+        response_format={"type": "json_object"},
+        temperature=0.0,
+    )
+
+    response_json = await provider.chat_complete(request_json)
+    assert response_json.choices[0].message.content, "Empty JSON response from OpenAI."
+
+    try:
+        data = json.loads(response_json.choices[0].message.content)
+        print(f"Result: SUCCESS (Parsed JSON: {data})")
+    except json.JSONDecodeError:
+        error_msg = f"Result: FAILURE (Invalid JSON: {response_json.choices[0].message.content})"
+        print(error_msg)
+
+    print("\n--- OpenAI Tests Completed ---")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_real_openai_call())

--- a/src/llm_gateway/api/v1/gateway.py
+++ b/src/llm_gateway/api/v1/gateway.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class GatewayConfig(BaseModel):
+    default_provider: str
+
+
+@router.get("/config", response_model=GatewayConfig)
+async def get_config(request: Request):
+    router_instance = request.app.state.router
+    return GatewayConfig(default_provider=router_instance.default_provider)
+
+
+@router.post("/config", response_model=GatewayConfig)
+async def update_config(request: Request, config: GatewayConfig):
+    router_instance = request.app.state.router
+    try:
+        router_instance.set_default_provider(config.default_provider)
+        return GatewayConfig(default_provider=router_instance.default_provider)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e

--- a/src/llm_gateway/core/config.py
+++ b/src/llm_gateway/core/config.py
@@ -11,6 +11,8 @@ class Settings(BaseSettings):
 
     # Model Configuration
     GEMINI_DEFAULT_MODEL: str = "gemini-2.0-flash-lite-001"
+    OPENAI_DEFAULT_MODEL: str = "gpt-4o-mini"
+    DEFAULT_PROVIDER: str = "google"  # "google" or "openai"
 
     # Observability
     LANGSMITH_TRACING: bool = False

--- a/src/llm_gateway/extensions/providers/__init__.py
+++ b/src/llm_gateway/extensions/providers/__init__.py
@@ -1,1 +1,2 @@
 from .gemini import GeminiProvider
+from .openai import OpenAIProvider

--- a/src/llm_gateway/extensions/providers/openai.py
+++ b/src/llm_gateway/extensions/providers/openai.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+from openai import AsyncOpenAI
+
+from llm_gateway.core.config import settings
+from llm_gateway.core.interfaces import BaseLLMProvider
+from llm_gateway.schemas.chat import (
+    ChatMessage,
+    ChatRequest,
+    ChatResponse,
+    ChatResponseChoice,
+)
+
+
+class OpenAIProvider(BaseLLMProvider):
+    def __init__(self):
+        self.client = None
+        if settings.OPENAI_API_KEY:
+            self.client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
+
+    def _convert_messages(self, messages: list[ChatMessage]) -> list[dict[str, Any]]:
+        """
+        Convert standard ChatMessage to OpenAI message format.
+        """
+        openai_messages = []
+        for msg in messages:
+            m = {"role": msg.role, "content": msg.content}
+            if msg.tool_calls:
+                m["tool_calls"] = msg.tool_calls
+            if msg.tool_call_id:
+                m["tool_call_id"] = msg.tool_call_id
+            openai_messages.append(m)
+        return openai_messages
+
+    async def chat_complete(self, request: ChatRequest) -> ChatResponse:
+        if not self.client:
+            if not settings.OPENAI_API_KEY:
+                raise ValueError("OPENAI_API_KEY is not set.")
+            self.client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
+
+        model_name = request.model
+        if model_name in ["openai", "gpt"]:
+            model_name = settings.OPENAI_DEFAULT_MODEL
+
+        # Prepare arguments for OpenAI API
+        kwargs = {
+            "model": model_name,
+            "messages": self._convert_messages(request.messages),
+            "temperature": request.temperature,
+            "max_tokens": request.max_tokens,
+            "stream": request.stream,
+        }
+
+        if request.response_format:
+            kwargs["response_format"] = request.response_format
+
+        if request.tools:
+            kwargs["tools"] = request.tools
+            if request.tool_choice:
+                kwargs["tool_choice"] = request.tool_choice
+
+        # Call OpenAI API
+        response = await self.client.chat.completions.create(**kwargs)
+
+        # Convert OpenAI response to our ChatResponse
+        choices = []
+        for choice in response.choices:
+            tool_calls = None
+            if choice.message.tool_calls:
+                tool_calls = [
+                    {
+                        "id": tc.id,
+                        "type": tc.type,
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                    for tc in choice.message.tool_calls
+                ]
+
+            choices.append(
+                ChatResponseChoice(
+                    index=choice.index,
+                    message=ChatMessage(
+                        role="assistant",
+                        content=choice.message.content or "",
+                        tool_calls=tool_calls,
+                    ),
+                    finish_reason=choice.finish_reason,
+                )
+            )
+
+        return ChatResponse(
+            id=response.id,
+            created=response.created,
+            model=response.model,
+            choices=choices,
+        )

--- a/src/llm_gateway/extensions/routers/simple_router.py
+++ b/src/llm_gateway/extensions/routers/simple_router.py
@@ -1,3 +1,4 @@
+from llm_gateway.core.config import settings
 from llm_gateway.core.interfaces import BaseLLMProvider, BaseRouter
 from llm_gateway.schemas.chat import ChatRequest, ChatResponse
 
@@ -5,13 +6,34 @@ from llm_gateway.schemas.chat import ChatRequest, ChatResponse
 class SimpleRouter(BaseRouter):
     def __init__(self, providers: dict[str, BaseLLMProvider]):
         self.providers = providers
+        self.default_provider = settings.DEFAULT_PROVIDER
 
     def _select_provider(self, model: str) -> BaseLLMProvider:
+        # 1. 특정 모델명이 명시된 경우 (강제 적용)
+        if model.startswith(("gpt", "o1", "text-embedding-3")):
+            return self.providers["openai"]
         if model.startswith("gemini"):
             return self.providers["google"]
 
-        raise ValueError(f"Unsupported model: {model}")
+        # 2. 모델명이 'default'이거나 특정되지 않은 경우
+        if model in ["default", "openai", "google"]:
+            provider_key = (
+                "openai"
+                if model == "openai"
+                else "google"
+                if model == "google"
+                else self.default_provider
+            )
+            return self.providers[provider_key]
+
+        # 3. 그 외 기본 설정된 공급자 사용
+        return self.providers[self.default_provider]
 
     async def route_chat(self, request: ChatRequest) -> ChatResponse:
         provider = self._select_provider(request.model)
         return await provider.chat_complete(request)
+
+    def set_default_provider(self, provider: str):
+        if provider not in self.providers:
+            raise ValueError(f"Provider {provider} not available.")
+        self.default_provider = provider

--- a/src/llm_gateway/main.py
+++ b/src/llm_gateway/main.py
@@ -1,9 +1,9 @@
 from fastapi import FastAPI
 
-from llm_gateway.api.v1 import chat
+from llm_gateway.api.v1 import chat, gateway
 from llm_gateway.core.config import settings
 from llm_gateway.core.engine import LLMEngine
-from llm_gateway.extensions.providers import GeminiProvider
+from llm_gateway.extensions.providers import GeminiProvider, OpenAIProvider
 from llm_gateway.extensions.routers import SimpleRouter
 
 
@@ -13,14 +13,21 @@ def app() -> FastAPI:
         openapi_url=f"{settings.API_V1_STR}/openapi.json",
     )
 
-    providers = {"google": GeminiProvider()}
+    providers = {
+        "google": GeminiProvider(),
+        "openai": OpenAIProvider(),
+    }
 
     router = SimpleRouter(providers)
     engine = LLMEngine(router)
 
-    app.state.engine = engine  # 여기 중요
+    app.state.engine = engine
+    app.state.router = router  # Allow direct access to router for config
 
     app.include_router(chat.router, prefix=f"{settings.API_V1_STR}/chat", tags=["chat"])
+    app.include_router(
+        gateway.router, prefix=f"{settings.API_V1_STR}/gateway", tags=["gateway"]
+    )
 
     @app.get("/")
     def root():

--- a/tests/api/test_chat.py
+++ b/tests/api/test_chat.py
@@ -57,3 +57,17 @@ def test_chat_completions_provider_error(mock_engine, client_instance):
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Invalid model"
+
+
+def test_chat_completions_internal_error(mock_engine, client_instance):
+    mock_engine.side_effect = Exception("Unexpected error")
+
+    payload = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "Hi"}],
+    }
+
+    response = client_instance.post("/api/v1/chat/completions", json=payload)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Internal Server Error"

--- a/tests/api/test_gateway.py
+++ b/tests/api/test_gateway.py
@@ -1,0 +1,41 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from llm_gateway.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app())
+
+
+def test_get_gateway_config(client):
+    response = client.get("/api/v1/gateway/config")
+    assert response.status_code == 200
+    data = response.json()
+    assert "default_provider" in data
+    assert data["default_provider"] in ["google", "openai"]
+
+
+def test_update_gateway_config_success(client):
+    # Test switching to openai
+    response = client.post(
+        "/api/v1/gateway/config", json={"default_provider": "openai"}
+    )
+    assert response.status_code == 200
+    assert response.json()["default_provider"] == "openai"
+
+    # Test switching back to google
+    response = client.post(
+        "/api/v1/gateway/config", json={"default_provider": "google"}
+    )
+    assert response.status_code == 200
+    assert response.json()["default_provider"] == "google"
+
+
+def test_update_gateway_config_invalid_provider(client):
+    response = client.post(
+        "/api/v1/gateway/config", json={"default_provider": "invalid"}
+    )
+    assert response.status_code == 400
+    assert "Provider invalid not available" in response.json()["detail"]

--- a/tests/extensions/test_openai.py
+++ b/tests/extensions/test_openai.py
@@ -1,0 +1,139 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llm_gateway.core.config import settings
+from llm_gateway.extensions.providers.openai import OpenAIProvider
+from llm_gateway.schemas.chat import ChatMessage, ChatRequest
+
+
+@pytest.fixture
+def mock_openai_client():
+    with patch("llm_gateway.extensions.providers.openai.AsyncOpenAI") as mock:
+        client_instance = mock.return_value
+        client_instance.chat = MagicMock()
+        client_instance.chat.completions = MagicMock()
+        client_instance.chat.completions.create = AsyncMock()
+        yield client_instance
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_complete_basic(mock_openai_client):
+    # Setup mock response
+    mock_choice = MagicMock()
+    mock_choice.index = 0
+    mock_choice.message.role = "assistant"
+    mock_choice.message.content = "Hello from OpenAI"
+    mock_choice.message.tool_calls = None
+    mock_choice.finish_reason = "stop"
+
+    mock_response = MagicMock()
+    mock_response.id = "chatcmpl-123"
+    mock_response.created = 123456789
+    mock_response.model = "gpt-4o-mini"
+    mock_response.choices = [mock_choice]
+
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    with patch.object(settings, "OPENAI_API_KEY", "test-key"):
+        provider = OpenAIProvider()
+        request = ChatRequest(
+            model="gpt-4o-mini", messages=[ChatMessage(role="user", content="hello")]
+        )
+
+        response = await provider.chat_complete(request)
+
+        assert response.choices[0].message.content == "Hello from OpenAI"
+        assert response.model == "gpt-4o-mini"
+        mock_openai_client.chat.completions.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_complete_with_tools(mock_openai_client):
+    # Setup mock tool response
+    mock_tool_call = MagicMock()
+    mock_tool_call.id = "call_123"
+    mock_tool_call.type = "function"
+    mock_tool_call.function.name = "get_weather"
+    mock_tool_call.function.arguments = '{"location": "Seoul"}'
+
+    mock_choice = MagicMock()
+    mock_choice.index = 0
+    mock_choice.message.role = "assistant"
+    mock_choice.message.content = None
+    mock_choice.message.tool_calls = [mock_tool_call]
+    mock_choice.finish_reason = "tool_calls"
+
+    mock_response = MagicMock()
+    mock_response.id = "chatcmpl-tool"
+    mock_response.created = 123456789
+    mock_response.model = "gpt-4o"
+    mock_response.choices = [mock_choice]
+
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    with patch.object(settings, "OPENAI_API_KEY", "test-key"):
+        provider = OpenAIProvider()
+        request = ChatRequest(
+            model="gpt-4o",
+            messages=[
+                ChatMessage(role="system", content="You are a helpful assistant"),
+                ChatMessage(role="user", content="What's the weather?"),
+                ChatMessage(
+                    role="assistant",
+                    content=None,
+                    tool_calls=[
+                        {
+                            "id": "call_123",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{}"},
+                        }
+                    ],
+                ),
+                ChatMessage(role="tool", content="Sunny", tool_call_id="call_123"),
+            ],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+        )
+
+        response = await provider.chat_complete(request)
+
+        assert response.choices[0].finish_reason == "tool_calls"
+        assert (
+            response.choices[0].message.tool_calls[0]["function"]["name"]
+            == "get_weather"
+        )
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_complete_json_mode(mock_openai_client):
+    mock_response = MagicMock()
+    mock_response.id = "chatcmpl-json"
+    mock_response.created = 123456789
+    mock_response.model = "gpt-4o"
+    mock_response.choices = []
+
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    with patch.object(settings, "OPENAI_API_KEY", "test-key"):
+        provider = OpenAIProvider()
+        request = ChatRequest(
+            model="gpt-4o",
+            messages=[ChatMessage(role="user", content="Output JSON")],
+            response_format={"type": "json_object"},
+        )
+
+        await provider.chat_complete(request)
+
+        _, kwargs = mock_openai_client.chat.completions.create.call_args
+        assert kwargs["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_complete_no_api_key():
+    with patch.object(settings, "OPENAI_API_KEY", None):
+        provider = OpenAIProvider()
+        # Reset client if it was initialized in previous tests
+        provider.client = None
+        request = ChatRequest(model="gpt-4o-mini", messages=[])
+        with pytest.raises(ValueError, match="OPENAI_API_KEY is not set"):
+            await provider.chat_complete(request)

--- a/tests/extensions/test_router.py
+++ b/tests/extensions/test_router.py
@@ -1,0 +1,62 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from llm_gateway.extensions.routers.simple_router import SimpleRouter
+from llm_gateway.schemas.chat import ChatMessage, ChatRequest
+
+
+@pytest.fixture
+def mock_providers():
+    return {"google": MagicMock(), "openai": MagicMock()}
+
+
+@pytest.fixture
+def router(mock_providers):
+    return SimpleRouter(mock_providers)
+
+
+@pytest.mark.asyncio
+async def test_router_select_openai_by_model_name(router, mock_providers):
+    request = ChatRequest(
+        model="gpt-4o", messages=[ChatMessage(role="user", content="hi")]
+    )
+    mock_providers["openai"].chat_complete = AsyncMock()
+
+    await router.route_chat(request)
+    mock_providers["openai"].chat_complete.assert_called_once()
+    mock_providers["google"].chat_complete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_router_select_google_by_model_name(router, mock_providers):
+    request = ChatRequest(
+        model="gemini-pro", messages=[ChatMessage(role="user", content="hi")]
+    )
+    mock_providers["google"].chat_complete = AsyncMock()
+
+    await router.route_chat(request)
+    mock_providers["google"].chat_complete.assert_called_once()
+    mock_providers["openai"].chat_complete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_router_default_provider(router, mock_providers):
+    router.set_default_provider("openai")
+    request = ChatRequest(
+        model="default", messages=[ChatMessage(role="user", content="hi")]
+    )
+    mock_providers["openai"].chat_complete = AsyncMock()
+
+    await router.route_chat(request)
+    mock_providers["openai"].chat_complete.assert_called_once()
+
+    router.set_default_provider("google")
+    mock_providers["google"].chat_complete = AsyncMock()
+    await router.route_chat(request)
+    mock_providers["google"].chat_complete.assert_called_once()
+
+
+def test_router_set_invalid_provider(router):
+    with pytest.raises(ValueError, match="Provider invalid not available"):
+        router.set_default_provider("invalid")

--- a/uv.lock
+++ b/uv.lock
@@ -352,6 +352,91 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/29/499f8c9eaa8a16751b1c0e45e6f5f1761d180da873d417996cc7bddc8eef/jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096", size = 311157, upload-time = "2026-02-02T12:35:37.758Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/566364c777d2ab450b92100bea11333c64c38d32caf8dc378b48e5b20c46/jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911", size = 319729, upload-time = "2026-02-02T12:35:39.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/560f13ec5e4f116d8ad2658781646cca91b617ae3b8758d4a5076b278f70/jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701", size = 354766, upload-time = "2026-02-02T12:35:40.662Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0d/061faffcfe94608cbc28a0d42a77a74222bdf5055ccdbe5fd2292b94f510/jiter-0.13.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7e287d7fbd02cb6e22f9a00dd9c9cd504c40a61f2c61e7e1f9690a82726b4c", size = 362587, upload-time = "2026-02-02T12:35:42.025Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/c66a7864982fd38a9773ec6e932e0398d1262677b8c60faecd02ffb67bf3/jiter-0.13.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47455245307e4debf2ce6c6e65a717550a0244231240dcf3b8f7d64e4c2f22f4", size = 487537, upload-time = "2026-02-02T12:35:43.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/86/84eb4352cd3668f16d1a88929b5888a3fe0418ea8c1dfc2ad4e7bf6e069a/jiter-0.13.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9da221dca6e0429c2704c1b3655fe7b025204a71d4d9b73390c759d776d165", size = 373717, upload-time = "2026-02-02T12:35:44.928Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/09/9fe4c159358176f82d4390407a03f506a8659ed13ca3ac93a843402acecf/jiter-0.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24ab43126d5e05f3d53a36a8e11eb2f23304c6c1117844aaaf9a0aa5e40b5018", size = 362683, upload-time = "2026-02-02T12:35:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5e/85f3ab9caca0c1d0897937d378b4a515cae9e119730563572361ea0c48ae/jiter-0.13.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9da38b4fedde4fb528c740c2564628fbab737166a0e73d6d46cb4bb5463ff411", size = 392345, upload-time = "2026-02-02T12:35:48.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4c/05b8629ad546191939e6f0c2f17e29f542a398f4a52fb987bc70b6d1eb8b/jiter-0.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b34c519e17658ed88d5047999a93547f8889f3c1824120c26ad6be5f27b6cf5", size = 517775, upload-time = "2026-02-02T12:35:49.482Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/88/367ea2eb6bc582c7052e4baf5ddf57ebe5ab924a88e0e09830dfb585c02d/jiter-0.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2a6394e6af690d462310a86b53c47ad75ac8c21dc79f120714ea449979cb1d3", size = 551325, upload-time = "2026-02-02T12:35:51.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/12/fa377ffb94a2f28c41afaed093e0d70cfe512035d5ecb0cad0ae4792d35e/jiter-0.13.0-cp311-cp311-win32.whl", hash = "sha256:0f0c065695f616a27c920a56ad0d4fc46415ef8b806bf8fc1cacf25002bd24e1", size = 204709, upload-time = "2026-02-02T12:35:52.467Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/16/8e8203ce92f844dfcd3d9d6a5a7322c77077248dbb12da52d23193a839cd/jiter-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0733312953b909688ae3c2d58d043aa040f9f1a6a75693defed7bc2cc4bf2654", size = 204560, upload-time = "2026-02-02T12:35:53.925Z" },
+    { url = "https://files.pythonhosted.org/packages/44/26/97cc40663deb17b9e13c3a5cf29251788c271b18ee4d262c8f94798b8336/jiter-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:5d9b34ad56761b3bf0fbe8f7e55468704107608512350962d3317ffd7a4382d5", size = 189608, upload-time = "2026-02-02T12:35:55.304Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/3c29819a27178d0e461a8571fb63c6ae38be6dc36b78b3ec2876bbd6a910/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b1cbfa133241d0e6bdab48dcdc2604e8ba81512f6bbd68ec3e8e1357dd3c316c", size = 307016, upload-time = "2026-02-02T12:37:42.755Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/60993e4b07b1ac5ebe46da7aa99fdbb802eb986c38d26e3883ac0125c4e0/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:db367d8be9fad6e8ebbac4a7578b7af562e506211036cba2c06c3b998603c3d2", size = 305024, upload-time = "2026-02-02T12:37:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fa/2227e590e9cf98803db2811f172b2d6460a21539ab73006f251c66f44b14/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45f6f8efb2f3b0603092401dc2df79fa89ccbc027aaba4174d2d4133ed661434", size = 339337, upload-time = "2026-02-02T12:37:46.668Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/92/015173281f7eb96c0ef580c997da8ef50870d4f7f4c9e03c845a1d62ae04/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:597245258e6ad085d064780abfb23a284d418d3e61c57362d9449c6c7317ee2d", size = 346395, upload-time = "2026-02-02T12:37:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
 name = "llm-gateway"
 version = "0.1.0"
 source = { editable = "." }
@@ -359,6 +444,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "google-genai" },
     { name = "httpx" },
+    { name = "openai" },
     { name = "pydantic-settings" },
     { name = "tenacity" },
     { name = "uvicorn" },
@@ -377,6 +463,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "google-genai", specifier = ">=1.59.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "openai", specifier = ">=2.16.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "tenacity", specifier = ">=9.1.2" },
     { name = "uvicorn", specifier = ">=0.40.0" },
@@ -388,6 +475,25 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "respx", specifier = ">=0.22.0" },
+]
+
+[[package]]
+name = "openai"
+version = "2.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/6c/e4c964fcf1d527fdf4739e7cc940c60075a4114d50d03871d5d5b1e13a88/openai-2.16.0.tar.gz", hash = "sha256:42eaa22ca0d8ded4367a77374104d7a2feafee5bd60a107c3c11b5243a11cd12", size = 629649, upload-time = "2026-01-27T23:28:02.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/83/0315bf2cfd75a2ce8a7e54188e9456c60cec6c0cf66728ed07bd9859ff26/openai-2.16.0-py3-none-any.whl", hash = "sha256:5f46643a8f42899a84e80c38838135d7038e7718333ce61396994f887b09a59b", size = 1068612, upload-time = "2026-01-27T23:28:00.356Z" },
 ]
 
 [[package]]
@@ -738,6 +844,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 관련 이슈

- Close #21

## 변경 사항

- **OpenAI Provider 추가**: 공식 `openai` Python SDK를 사용한 `OpenAIProvider` 구현
- **라우팅 로직 고도화**:
  - 모델명 접두어(`gpt-`, `o1-`)에 따른 자동 공급자 할당 기능 추가
  - `gemini-` 접두어에 따른 Gemini 자동 할당
  - `default` 별칭 사용 시 설정된 기본 공급자로 라우팅
- **게이트웨이 관리 API 추가**: `/api/v1/gateway/config` 엔드포인트를 통해 런타임에 기본 공급자 동적 변경 가능
- **테스트 강화**:
  - 신규 기능(OpenAI, Router, 관리 API)에 대한 단위 테스트 추가 (전체 커버리지 86% 달성)
  - 실제 API 호출 확인을 위한 스크립트(`scripts/test_openai_real.py`, `scripts/test_gateway_api.py`) 추가
- **문서 업데이트**: `docs/plan.md` 로드맵 현행화

## 배경

- 기존 Google Gemini 외에 OpenAI 모델 지원이 필요함
- 클라이언트 요청에 따라 모델을 유연하게 전환하고, 운영 중에도 서버 재시작 없이 기본 모델 설정을 변경할 수 있는 인프라 구축이 목적임

## 구현 상세

- **경량성 유지**: 프레임워크 의존성을 줄이기 위해 LangChain 대신 OpenAI 순수 SDK를 직접 사용
- **인터페이스 준수**: `BaseLLMProvider` 추상 클래스를 상속받아 기존 Gemini 구현체와 일관된 인터페이스 유지
- **상태 관리**: FastAPI의 `app.state`를 활용하여 라우터의 설정 상태를 메모리상에서 관리

## 체크리스트

- [x] 로컬에서 정상 동작 확인 (Gemini 실호출 및 API 라우팅 테스트 완료)
- [x] 테스트 코드 추가/수정 (19개 테스트 케이스 통과)
- [x] 문서 업데이트 (`docs/plan.md` 업데이트 완료)
- [x] 불필요한 코드/주석 제거
