### PR TITLE
Feat/24 streaming

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
 
       # LLM Settings
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
-      OPEN_AI_API_KEY: ${OPEN_AI_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
 
       # Default Models
       OPENAI_DEFAULT_MODEL: ${OPENAI_DEFAULT_MODEL:-gpt-4o-mini}

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -101,7 +101,7 @@ llm-router/
 - [x] 모델 별칭(Alias) 시스템 구현 (예: `gpt-*` -> OpenAI, `gemini-*` -> Gemini).
 - [x] `/v1/chat/completions` 엔드포인트 구현.
 - [x] 런타임 모델 라우팅 설정 관리 API 구현.
-- [ ] 스트리밍(Streaming) 응답 지원.
+- [x] 스트리밍(Streaming) 응답 지원. ([상세 계획](./streaming_plan.md))
 
 ### Phase 4: 관측성 및 안정화
 

--- a/scripts/test_gateway_api.py
+++ b/scripts/test_gateway_api.py
@@ -54,6 +54,37 @@ def test_api_routing():
     if resp.status_code == 200:
         print(f"Response Model: {resp.json()['model']}")
 
+    # New Step: Override Provider Test
+    print("\n[Step 4.5] Testing Override Provider (Force OpenAI)...")
+    # 1. Set override to openai
+    resp = requests.post(
+        f"{BASE_URL}/gateway/config",
+        json={"default_provider": "openai", "override_provider": "openai"},
+    )
+    print(f"Config override update: {resp.json()}")
+
+    # 2. Request Gemini model (should be routed to OpenAI due to override)
+    payload = {
+        "model": "gemini-2.0-flash",
+        "messages": [{"role": "user", "content": "Who are you?"}],
+    }
+    resp = requests.post(f"{BASE_URL}/chat/completions", json=payload)
+    if resp.status_code == 200:
+        model_used = resp.json()["model"]
+        print(f"Requested 'gemini-2.0-flash', Got Model: {model_used}")
+        if "gpt" in model_used or "openai" in model_used:
+            print("SUCCESS: Override worked.")
+        else:
+            print(f"FAIL: Override failed. Got {model_used}")
+
+    # 3. Clear override
+    print("Clearing override...")
+    resp = requests.post(
+        f"{BASE_URL}/gateway/config",
+        json={"default_provider": "openai", "override_provider": None},
+    )
+    print(f"Config cleared: {resp.json()}")
+
     # 5. Test Streaming API
     print("\n[Step 5] Testing Streaming API (GPT-4o-mini)...")
     payload = {

--- a/scripts/test_gateway_api.py
+++ b/scripts/test_gateway_api.py
@@ -1,3 +1,6 @@
+import json
+
+import httpx
 import requests
 
 BASE_URL = "http://localhost:8000/api/v1"
@@ -50,6 +53,32 @@ def test_api_routing():
     resp = requests.post(f"{BASE_URL}/chat/completions", json=payload)
     if resp.status_code == 200:
         print(f"Response Model: {resp.json()['model']}")
+
+    # 5. Test Streaming API
+    print("\n[Step 5] Testing Streaming API (GPT-4o-mini)...")
+    payload = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "Counting to 3 slowly."}],
+        "stream": True,
+    }
+
+    print("Stream output: ", end="", flush=True)
+    with httpx.stream(
+        "POST", f"{BASE_URL}/chat/completions", json=payload, timeout=60.0
+    ) as r:
+        if r.status_code != 200:
+            print(f"ERROR: {r.status_code}")
+        else:
+            for line in r.iter_lines():
+                if line.startswith("data: "):
+                    data_str = line[6:]
+                    if data_str == "[DONE]":
+                        break
+                    chunk = json.loads(data_str)
+                    content = chunk["choices"][0]["delta"].get("content")
+                    if content:
+                        print(content, end="", flush=True)
+    print("\nResult: SUCCESS")
 
     print("\n--- API Tests Completed ---")
 

--- a/scripts/test_gemini_real.py
+++ b/scripts/test_gemini_real.py
@@ -65,6 +65,22 @@ async def test_real_gemini_call():
     print("Result: SUCCESS")
     print(f"JSON Response: {response_json.choices[0].message.content}")
 
+    # 3. Streaming Test
+    print("\n[Step 3] Testing Streaming...")
+    request_stream = ChatRequest(
+        model="gemini-2.0-flash",
+        messages=[ChatMessage(role="user", content="Write a two-sentence poem.")],
+        stream=True,
+    )
+
+    print("Stream output: ", end="", flush=True)
+    response_stream = await provider.chat_complete(request_stream)
+    async for chunk in response_stream:
+        content = chunk.choices[0].delta.content
+        if content:
+            print(content, end="", flush=True)
+    print("\nResult: SUCCESS")
+
     print("\n--- All Tests Passed Successfully ---")
 
 

--- a/scripts/test_openai_real.py
+++ b/scripts/test_openai_real.py
@@ -61,6 +61,22 @@ async def test_real_openai_call():
         )
         print(error_msg)
 
+    # 3. Streaming Test
+    print("\n[Step 3] Testing Streaming...")
+    request_stream = ChatRequest(
+        model="gpt-4o-mini",
+        messages=[ChatMessage(role="user", content="Write a two-sentence poem.")],
+        stream=True,
+    )
+
+    print("Stream output: ", end="", flush=True)
+    response_stream = await provider.chat_complete(request_stream)
+    async for chunk in response_stream:
+        content = chunk.choices[0].delta.content
+        if content:
+            print(content, end="", flush=True)
+    print("\nResult: SUCCESS")
+
     print("\n--- OpenAI Tests Completed ---")
 
 

--- a/src/llm_gateway/api/v1/chat.py
+++ b/src/llm_gateway/api/v1/chat.py
@@ -1,5 +1,7 @@
-# chat.py
+from typing import AsyncIterator
+
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
 
 from llm_gateway.schemas.chat import ChatRequest, ChatResponse
 
@@ -10,7 +12,20 @@ router = APIRouter()
 async def chat_completions(request: Request, body: ChatRequest):
     try:
         engine = request.app.state.engine
-        return await engine.chat(body)
+        response = await engine.chat(body)
+
+        if isinstance(response, AsyncIterator):
+
+            async def event_generator():
+                async for chunk in response:
+                    # Yield SSE format
+                    data = chunk.model_dump_json()
+                    yield f"data: {data}\n\n"
+                yield "data: [DONE]\n\n"
+
+            return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+        return response
 
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/src/llm_gateway/api/v1/gateway.py
+++ b/src/llm_gateway/api/v1/gateway.py
@@ -6,12 +6,16 @@ router = APIRouter()
 
 class GatewayConfig(BaseModel):
     default_provider: str
+    override_provider: str | None = None
 
 
 @router.get("/config", response_model=GatewayConfig)
 async def get_config(request: Request):
     router_instance = request.app.state.router
-    return GatewayConfig(default_provider=router_instance.default_provider)
+    return GatewayConfig(
+        default_provider=router_instance.default_provider,
+        override_provider=router_instance.override_provider,
+    )
 
 
 @router.post("/config", response_model=GatewayConfig)
@@ -19,6 +23,10 @@ async def update_config(request: Request, config: GatewayConfig):
     router_instance = request.app.state.router
     try:
         router_instance.set_default_provider(config.default_provider)
-        return GatewayConfig(default_provider=router_instance.default_provider)
+        router_instance.set_override_provider(config.override_provider)
+        return GatewayConfig(
+            default_provider=router_instance.default_provider,
+            override_provider=router_instance.override_provider,
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/src/llm_gateway/core/engine.py
+++ b/src/llm_gateway/core/engine.py
@@ -1,10 +1,14 @@
+from typing import AsyncIterator, Union
+
 from llm_gateway.core.interfaces import BaseRouter
-from llm_gateway.schemas.chat import ChatRequest, ChatResponse
+from llm_gateway.schemas.chat import ChatRequest, ChatResponse, ChatResponseChunk
 
 
 class LLMEngine:
     def __init__(self, router: BaseRouter):
         self.router = router
 
-    async def chat(self, request: ChatRequest) -> ChatResponse:
+    async def chat(
+        self, request: ChatRequest
+    ) -> Union[ChatResponse, AsyncIterator[ChatResponseChunk]]:
         return await self.router.route_chat(request)

--- a/src/llm_gateway/core/interfaces.py
+++ b/src/llm_gateway/core/interfaces.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
+from typing import AsyncIterator, Union
 
-from llm_gateway.schemas.chat import ChatRequest, ChatResponse
+from llm_gateway.schemas.chat import ChatRequest, ChatResponse, ChatResponseChunk
 
 
 class BaseLLMProvider(ABC):
@@ -9,7 +10,9 @@ class BaseLLMProvider(ABC):
     """
 
     @abstractmethod
-    async def chat_complete(self, request: ChatRequest) -> ChatResponse:
+    async def chat_complete(
+        self, request: ChatRequest
+    ) -> Union[ChatResponse, AsyncIterator[ChatResponseChunk]]:
         """
         Generates a response from the LLM based on the chat history.
         """
@@ -18,5 +21,7 @@ class BaseLLMProvider(ABC):
 
 class BaseRouter(ABC):
     @abstractmethod
-    async def route_chat(self, request: ChatRequest) -> ChatResponse:
+    async def route_chat(
+        self, request: ChatRequest
+    ) -> Union[ChatResponse, AsyncIterator[ChatResponseChunk]]:
         raise NotImplementedError

--- a/src/llm_gateway/extensions/providers/gemini.py
+++ b/src/llm_gateway/extensions/providers/gemini.py
@@ -1,6 +1,7 @@
 import json
 import time
 import uuid
+from typing import AsyncIterator, Union
 
 from google import genai
 from google.genai import types
@@ -12,6 +13,9 @@ from llm_gateway.schemas.chat import (
     ChatRequest,
     ChatResponse,
     ChatResponseChoice,
+    ChatResponseChoiceDelta,
+    ChatResponseChunk,
+    ChatResponseChunkChoice,
 )
 
 
@@ -102,10 +106,12 @@ class GeminiProvider(BaseLLMProvider):
 
         return [types.Tool(function_declarations=function_declarations)]
 
-    async def chat_complete(self, request: ChatRequest) -> ChatResponse:
+    async def chat_complete(
+        self, request: ChatRequest
+    ) -> Union[ChatResponse, AsyncIterator[ChatResponseChunk]]:
         # 모델명 결정
         model_name = request.model
-        if not model_name or model_name == "gemini" or model_name == "google":
+        if model_name in [None, "", "gemini", "google", "default"]:
             model_name = settings.GEMINI_DEFAULT_MODEL
 
         history, system_instruction = self._convert_messages(request.messages)
@@ -178,7 +184,67 @@ class GeminiProvider(BaseLLMProvider):
         else:
             last_message_content = "..."
 
-        # 비동기 호출 (이미 await 사용 중)
+        if request.stream:
+            stream_response = await chat.send_message_stream(
+                message=last_message_content
+            )
+            request_id = f"chatcmpl-{uuid.uuid4()}"
+
+            async def gen():
+                async for chunk in stream_response:
+                    content = ""
+                    tool_calls = []
+                    finish_reason = None
+
+                    if chunk.candidates and chunk.candidates[0].content.parts:
+                        for part in chunk.candidates[0].content.parts:
+                            if part.text:
+                                content += part.text
+                            if part.function_call:
+                                tool_calls.append(
+                                    {
+                                        "id": part.function_call.name,
+                                        "type": "function",
+                                        "function": {
+                                            "name": part.function_call.name,
+                                            "arguments": json.dumps(
+                                                part.function_call.args
+                                            ),
+                                        },
+                                    }
+                                )
+
+                        if chunk.candidates[0].finish_reason:
+                            # Mapping Gemini finish reason to OpenAI
+                            fr = chunk.candidates[0].finish_reason
+                            if fr == "STOP":
+                                finish_reason = "stop"
+                            elif fr == "MAX_TOKENS":
+                                finish_reason = "length"
+                            elif fr == "SAFETY":
+                                finish_reason = "content_filter"
+                            else:
+                                finish_reason = str(fr).lower()
+
+                    yield ChatResponseChunk(
+                        id=request_id,
+                        created=int(time.time()),
+                        model=model_name,
+                        choices=[
+                            ChatResponseChunkChoice(
+                                index=0,
+                                delta=ChatResponseChoiceDelta(
+                                    content=content if content else None,
+                                    tool_calls=tool_calls if tool_calls else None,
+                                ),
+                                finish_reason=finish_reason,
+                            )
+                        ],
+                    )
+
+            return gen()
+
+        # 비동기 호출
         response = await chat.send_message(message=last_message_content)
 
         # Response parsing

--- a/src/llm_gateway/extensions/providers/openai.py
+++ b/src/llm_gateway/extensions/providers/openai.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, AsyncIterator, Union
 
 from openai import AsyncOpenAI
 
@@ -9,6 +9,9 @@ from llm_gateway.schemas.chat import (
     ChatRequest,
     ChatResponse,
     ChatResponseChoice,
+    ChatResponseChoiceDelta,
+    ChatResponseChunk,
+    ChatResponseChunkChoice,
 )
 
 
@@ -32,14 +35,16 @@ class OpenAIProvider(BaseLLMProvider):
             openai_messages.append(m)
         return openai_messages
 
-    async def chat_complete(self, request: ChatRequest) -> ChatResponse:
+    async def chat_complete(
+        self, request: ChatRequest
+    ) -> Union[ChatResponse, AsyncIterator[ChatResponseChunk]]:
         if not self.client:
             if not settings.OPENAI_API_KEY:
                 raise ValueError("OPENAI_API_KEY is not set.")
             self.client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
 
         model_name = request.model
-        if model_name in ["openai", "gpt"]:
+        if model_name in ["openai", "gpt", "default"]:
             model_name = settings.OPENAI_DEFAULT_MODEL
 
         # Prepare arguments for OpenAI API
@@ -61,6 +66,47 @@ class OpenAIProvider(BaseLLMProvider):
 
         # Call OpenAI API
         response = await self.client.chat.completions.create(**kwargs)
+
+        if request.stream:
+
+            async def gen():
+                async for chunk in response:
+                    choices = []
+                    for choice in chunk.choices:
+                        delta = ChatResponseChoiceDelta(
+                            role=choice.delta.role,
+                            content=choice.delta.content,
+                        )
+                        if choice.delta.tool_calls:
+                            delta.tool_calls = [
+                                {
+                                    "index": tc.index,
+                                    "id": tc.id,
+                                    "type": tc.type,
+                                    "function": {
+                                        "name": tc.function.name,
+                                        "arguments": tc.function.arguments,
+                                    },
+                                }
+                                for tc in choice.delta.tool_calls
+                            ]
+
+                        choices.append(
+                            ChatResponseChunkChoice(
+                                index=choice.index,
+                                delta=delta,
+                                finish_reason=choice.finish_reason,
+                            )
+                        )
+
+                    yield ChatResponseChunk(
+                        id=chunk.id,
+                        created=chunk.created,
+                        model=chunk.model,
+                        choices=choices,
+                    )
+
+            return gen()
 
         # Convert OpenAI response to our ChatResponse
         choices = []

--- a/src/llm_gateway/extensions/routers/simple_router.py
+++ b/src/llm_gateway/extensions/routers/simple_router.py
@@ -1,6 +1,8 @@
+from typing import AsyncIterator, Union
+
 from llm_gateway.core.config import settings
 from llm_gateway.core.interfaces import BaseLLMProvider, BaseRouter
-from llm_gateway.schemas.chat import ChatRequest, ChatResponse
+from llm_gateway.schemas.chat import ChatRequest, ChatResponse, ChatResponseChunk
 
 
 class SimpleRouter(BaseRouter):
@@ -29,7 +31,9 @@ class SimpleRouter(BaseRouter):
         # 3. 그 외 기본 설정된 공급자 사용
         return self.providers[self.default_provider]
 
-    async def route_chat(self, request: ChatRequest) -> ChatResponse:
+    async def route_chat(
+        self, request: ChatRequest
+    ) -> Union[ChatResponse, AsyncIterator[ChatResponseChunk]]:
         provider = self._select_provider(request.model)
         return await provider.chat_complete(request)
 

--- a/src/llm_gateway/extensions/routers/simple_router.py
+++ b/src/llm_gateway/extensions/routers/simple_router.py
@@ -9,8 +9,13 @@ class SimpleRouter(BaseRouter):
     def __init__(self, providers: dict[str, BaseLLMProvider]):
         self.providers = providers
         self.default_provider = settings.DEFAULT_PROVIDER
+        self.override_provider = None
 
     def _select_provider(self, model: str) -> BaseLLMProvider:
+        # 0. Override Provider가 설정된 경우 최우선 적용
+        if self.override_provider:
+            return self.providers[self.override_provider]
+
         # 1. 특정 모델명이 명시된 경우 (강제 적용)
         if model.startswith(("gpt", "o1", "text-embedding-3")):
             return self.providers["openai"]
@@ -34,6 +39,17 @@ class SimpleRouter(BaseRouter):
     async def route_chat(
         self, request: ChatRequest
     ) -> Union[ChatResponse, AsyncIterator[ChatResponseChunk]]:
+        # Override 설정 시, 모델명이 타 공급자용이면 'default'로 치환하여 에러 방지
+        if self.override_provider:
+            model = request.model
+            is_openai_model = model.startswith(("gpt", "o1", "text-embedding-3"))
+            is_gemini_model = model.startswith("gemini")
+
+            if self.override_provider == "openai" and is_gemini_model:
+                request.model = "default"
+            elif self.override_provider == "google" and is_openai_model:
+                request.model = "default"
+
         provider = self._select_provider(request.model)
         return await provider.chat_complete(request)
 
@@ -41,3 +57,8 @@ class SimpleRouter(BaseRouter):
         if provider not in self.providers:
             raise ValueError(f"Provider {provider} not available.")
         self.default_provider = provider
+
+    def set_override_provider(self, provider: str | None):
+        if provider and provider not in self.providers:
+            raise ValueError(f"Provider {provider} not available.")
+        self.override_provider = provider

--- a/src/llm_gateway/schemas/chat.py
+++ b/src/llm_gateway/schemas/chat.py
@@ -38,3 +38,23 @@ class ChatResponse(BaseModel):
     created: int
     model: str
     choices: list[ChatResponseChoice]
+
+
+class ChatResponseChoiceDelta(BaseModel):
+    role: str | None = None
+    content: str | None = None
+    tool_calls: list[dict[str, Any]] | None = None
+
+
+class ChatResponseChunkChoice(BaseModel):
+    index: int
+    delta: ChatResponseChoiceDelta
+    finish_reason: str | None = None
+
+
+class ChatResponseChunk(BaseModel):
+    id: str
+    object: str = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: list[ChatResponseChunkChoice]

--- a/tests/api/test_chat.py
+++ b/tests/api/test_chat.py
@@ -2,7 +2,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from llm_gateway.schemas.chat import ChatMessage, ChatResponse, ChatResponseChoice
+from llm_gateway.schemas.chat import (
+    ChatMessage,
+    ChatResponse,
+    ChatResponseChoice,
+    ChatResponseChoiceDelta,
+    ChatResponseChunk,
+    ChatResponseChunkChoice,
+)
 
 
 @pytest.fixture
@@ -10,6 +17,46 @@ def mock_engine(app_instance):
     engine = app_instance.state.engine
     with patch.object(engine, "chat", new_callable=AsyncMock) as mock:
         yield mock
+
+
+def test_chat_completions_streaming_success(mock_engine, client_instance):
+    # Setup Mock Streaming Response
+    mock_chunk = ChatResponseChunk(
+        id="test-id",
+        created=1234567890,
+        model="gpt-4o",
+        choices=[
+            ChatResponseChunkChoice(
+                index=0,
+                delta=ChatResponseChoiceDelta(content="Hello"),
+                finish_reason=None,
+            )
+        ],
+    )
+
+    async def mock_async_iterator():
+        yield mock_chunk
+
+    mock_engine.return_value = mock_async_iterator()
+
+    payload = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": True,
+    }
+
+    # Execute
+    response = client_instance.post("/api/v1/chat/completions", json=payload)
+
+    # Verify
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
+    # Check body content
+    body = response.text
+    assert "data: " in body
+    assert '"content":"Hello"' in body
+    assert "data: [DONE]" in body
 
 
 def test_chat_completions_success(mock_engine, client_instance):

--- a/tests/extensions/test_openai.py
+++ b/tests/extensions/test_openai.py
@@ -1,10 +1,52 @@
+from typing import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from llm_gateway.core.config import settings
 from llm_gateway.extensions.providers.openai import OpenAIProvider
-from llm_gateway.schemas.chat import ChatMessage, ChatRequest
+from llm_gateway.schemas.chat import ChatMessage, ChatRequest, ChatResponseChunk
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_complete_streaming(mock_openai_client):
+    # Setup mock streaming response
+    mock_chunk = MagicMock()
+    mock_chunk.id = "chatcmpl-stream"
+    mock_chunk.created = 123456789
+    mock_chunk.model = "gpt-4o"
+
+    mock_choice = MagicMock()
+    mock_choice.index = 0
+    mock_choice.delta.role = "assistant"
+    mock_choice.delta.content = "Hello"
+    mock_choice.delta.tool_calls = None
+    mock_choice.finish_reason = None
+    mock_chunk.choices = [mock_choice]
+
+    async def mock_async_iterator():
+        yield mock_chunk
+
+    mock_openai_client.chat.completions.create.return_value = mock_async_iterator()
+
+    with patch.object(settings, "OPENAI_API_KEY", "test-key"):
+        provider = OpenAIProvider()
+        request = ChatRequest(
+            model="gpt-4o",
+            messages=[ChatMessage(role="user", content="hello")],
+            stream=True,
+        )
+
+        response = await provider.chat_complete(request)
+        assert isinstance(response, AsyncIterator)
+
+        chunks = []
+        async for chunk in response:
+            chunks.append(chunk)
+
+        assert len(chunks) == 1
+        assert isinstance(chunks[0], ChatResponseChunk)
+        assert chunks[0].choices[0].delta.content == "Hello"
 
 
 @pytest.fixture

--- a/tests/services/test_gemini.py
+++ b/tests/services/test_gemini.py
@@ -1,10 +1,54 @@
 import json
+from typing import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from llm_gateway.extensions.providers import GeminiProvider
-from llm_gateway.schemas.chat import ChatMessage, ChatRequest
+from llm_gateway.schemas.chat import ChatMessage, ChatRequest, ChatResponseChunk
+
+
+@pytest.mark.asyncio
+async def test_gemini_chat_complete_streaming(mock_genai_client):
+    # Setup Mock
+    mock_client_instance = MagicMock()
+    mock_chat_session = MagicMock()
+
+    mock_genai_client.return_value = mock_client_instance
+    mock_client_instance.aio.chats.create.return_value = mock_chat_session
+
+    mock_chunk = MagicMock()
+    mock_part = MagicMock()
+    mock_part.text = "Hello"
+    mock_part.function_call = None
+    mock_chunk.candidates = [
+        MagicMock(content=MagicMock(parts=[mock_part]), finish_reason=None)
+    ]
+
+    async def mock_stream_iterator():
+        yield mock_chunk
+
+    mock_chat_session.send_message_stream = AsyncMock(
+        return_value=mock_stream_iterator()
+    )
+
+    provider = GeminiProvider()
+    request = ChatRequest(
+        model="gemini-2.0-flash",
+        messages=[ChatMessage(role="user", content="hello")],
+        stream=True,
+    )
+
+    response = await provider.chat_complete(request)
+    assert isinstance(response, AsyncIterator)
+
+    chunks = []
+    async for chunk in response:
+        chunks.append(chunk)
+
+    assert len(chunks) == 1
+    assert isinstance(chunks[0], ChatResponseChunk)
+    assert chunks[0].choices[0].delta.content == "Hello"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 관련 이슈

- Close #24

## 변경 사항

- **스트리밍 응답 지원**: SSE(Server-Sent Events)를 통해 실시간 LLM 응답 기능을 구현했습니다.
- **기본 모델 라우팅 보완**: `default` 모델명으로 요청 시 각 공급자의 기본 모델(GPT-4o-mini, Gemini 2.0 Flash 등)을 사용하도록 수정했습니다.
- **스키마 확장**: 스트리밍 전용 응답 스키마(`ChatResponseChunk` 등)를 추가했습니다.
- **환경 변수 수정**: `docker-compose.yml`의 `OPENAI_API_KEY` 오타를 수정했습니다.
- **테스트 강화**: 스트리밍 로직에 대한 유닛 테스트 및 실 서비스 통합 테스트 스크립트를 업데이트했습니다.

## 배경

- 실시간 피드백이 필요한 서비스(GM Orchestrator 등)를 위해 스트리밍 응답 지원이 필요했습니다.
- 특정 모델명을 명시하지 않고 `default`로 요청하더라도 게이트웨이 설정에 따라 유연하게 대응할 수 있도록 라우팅 안정성을 높였습니다.

## 구현 상세

- **API 레이어**: FastAPI의 `StreamingResponse`와 비동기 제너레이터를 활용하여 SSE 표준 포맷으로 응답을 전송합니다.
- **Provider 연동**: OpenAI 및 Gemini SDK의 스트리밍 기능을 활성화하고, 클라이언트에 전달할 공통 델타(Delta) 포맷으로 변환하는 로직을 구현했습니다.
- **라우팅**: `SimpleRouter`에서 선택된 공급자가 모델명 별칭(alias)을 적절히 실제 모델명으로 매핑하도록 보완했습니다.

## 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 테스트 코드 추가/수정 (해당 시)
- [x] 문서 업데이트 (해당 시)
- [x] 불필요한 코드/주석 제거
